### PR TITLE
Fix sign of combinable effect upon device upload

### DIFF
--- a/hid-lg4ff.c
+++ b/hid-lg4ff.c
@@ -576,7 +576,7 @@ static int lg4ff_upload(struct lg4ff_device_entry *entry, struct klgd_command_st
 
 			ffpl_lvl_dir_to_x_y(level, effect->direction, &x, &y);
 			printk(KERN_DEBUG "Wheel constant: %i, direction %u  => %i\n", effect->u.constant.level, effect->direction, x * 0x7f / 0x7fff);
-			c->bytes[2+slot] = 0x80 + x * 0x7f / 0x7fff;
+			c->bytes[2+slot] = 0x80 - x * 0x7f / 0x7fff;
 			break;
 		}
 		case FF_DAMPER:


### PR DESCRIPTION
KLGDFF uses Linux-FF sign-convention of force levels:
i.e. positive means a positive force is applied by the computer to the wheel.
The same convention was used in good old ff-memless-next, and its lg4ff integration got it right:
https://github.com/edwin-v/linux-hid-lg4ff-next/blob/master/hid-lg4ff.c#L271

Note that Logitech adopts the DInput sign-convention of force levels, i.e. opposite to previously mentioned convention.
